### PR TITLE
re-implement `_mask_filter_results`

### DIFF
--- a/skipp/_ipp_wr/include/_ipp_wr.h
+++ b/skipp/_ipp_wr/include/_ipp_wr.h
@@ -30,6 +30,20 @@
 #include <stddef.h>
 #include "ipp.h"
 
+////////////////////////////////////////////////////////////////////////////////////////
+//
+// Adapter for ippiSet_<mode>_C1R functions,
+// where <mode> is 8u, 16u, 16s, 32s, 32f
+//
+////////////////////////////////////////////////////////////////////////////////////////
+IppStatus
+ippiSet_C1R(
+    IppDataType ippDataType,
+    double value,
+    void * pDst,
+    int dstStep,
+    IppiSize roiSize);
+
 /**************************************************************************************
  * filters module
  * funcs ...

--- a/skipp/_ipp_wr/src/_ipp_wr.c.src
+++ b/skipp/_ipp_wr/src/_ipp_wr.c.src
@@ -28,6 +28,43 @@
 
 #include "_ipp_wr.h"
 
+////////////////////////////////////////////////////////////////////////////////////////
+//
+// Adapter for ippiSet_<mode>_C1R functions,
+// where <mode> is 8u, 16u, 16s, 32s, 32f
+//
+////////////////////////////////////////////////////////////////////////////////////////
+IppStatus
+ippiSet_C1R(
+    IppDataType ippDataType,
+    double value,
+    void * pDst,
+    int dstStep,
+    IppiSize roiSize)
+{
+    IppStatus status = ippStsNoErr;
+
+    switch (ippDataType)
+    {
+    /**begin repeat
+     *
+     * #ipp_type = 8u, 16u, 16s, 32s, 32f#
+     */
+    case ipp@ipp_type@:
+    {
+        Ipp@ipp_type@ cast_value = (Ipp@ipp_type@)value;
+        status = ippiSet_@ipp_type@_C1R(cast_value, pDst, dstStep, roiSize);
+        break;
+    }
+    /**end repeat**/
+    default:
+    {
+        status = ippStsDataTypeErr;
+    }
+    }
+    return status;
+}
+
 /**************************************************************************************
  * filters module
  * funcs ...
@@ -57,19 +94,19 @@ ippiFilterBorderInit(
     case ipp16s:
     {
         status = ippiFilterBorderInit_16s(pKernel, kernelSize, divisor,
-        	ippImageDataType, numChannels, roundMode, pSpec);
+            ippImageDataType, numChannels, roundMode, pSpec);
         break;
     }
     case ipp32f:
     {
         status = ippiFilterBorderInit_32f(pKernel, kernelSize, ippImageDataType,
-        	numChannels, roundMode, pSpec);
+            numChannels, roundMode, pSpec);
         break;
     }
     case ipp64f:
     {
         status = ippiFilterBorderInit_64f(pKernel, kernelSize, ippImageDataType,
-        	numChannels, roundMode, pSpec);
+            numChannels, roundMode, pSpec);
         break;
     }
     default:
@@ -116,7 +153,7 @@ ippiFilterBorder(
         {
             Ipp@ipp_type@ ippbordervalue = (Ipp@ipp_type@)ippBorderValue;
             status = ippiFilterBorder_@ipp_type@_C1R(pSrc, srcStep, pDst, dstStep,roiSize,
-            	             ippBorderType, &ippbordervalue, pSpec, pBuffer);
+                             ippBorderType, &ippbordervalue, pSpec, pBuffer);
             break;
         }
         /**end repeat**/
@@ -140,7 +177,7 @@ ippiFilterBorder(
                                                 (Ipp@ipp_type@)ippBorderValue,
                                                 (Ipp@ipp_type@)ippBorderValue };
             status = ippiFilterBorder_@ipp_type@_C3R(pSrc, srcStep, pDst, dstStep, roiSize,
-            	 ippBorderType, ippbordervalue, pSpec, pBuffer);
+                 ippBorderType, ippbordervalue, pSpec, pBuffer);
             break;
         }
         /**end repeat**/
@@ -165,7 +202,7 @@ ippiFilterBorder(
                                                 (Ipp@ipp_type@)ippBorderValue,
                                                 (Ipp@ipp_type@)ippBorderValue };
             status = ippiFilterBorder_@ipp_type@_C4R(pSrc, srcStep, pDst, dstStep, roiSize,
-            	 ippBorderType, ippbordervalue, pSpec, pBuffer);
+                 ippBorderType, ippbordervalue, pSpec, pBuffer);
             break;
         }
         /**end repeat**/
@@ -290,7 +327,7 @@ ippiFilterMedianBorder(
         {
             Ipp@ipp_type@ ippbordervalue = (Ipp@ipp_type@)ippBorderValue;
             status = ippiFilterMedianBorder_@ipp_type@_C1R(pSrc, srcStep, pDst, dstStep,
-            	dstRoiSize, maskSize, ippBorderType, ippbordervalue, pBuffer);
+                dstRoiSize, maskSize, ippBorderType, ippbordervalue, pBuffer);
             break;
 
         }
@@ -315,7 +352,7 @@ ippiFilterMedianBorder(
                                                 (Ipp@ipp_type@)ippBorderValue,
                                                 (Ipp@ipp_type@)ippBorderValue };
             status = ippiFilterMedianBorder_@ipp_type@_C3R(pSrc, srcStep, pDst, dstStep,
-            	dstRoiSize, maskSize, ippBorderType, ippbordervalue, pBuffer);
+                dstRoiSize, maskSize, ippBorderType, ippbordervalue, pBuffer);
             break;
 
         }
@@ -430,19 +467,19 @@ ippiFilter@filter_type@@filter_magnitude@Border(
         if (ippSrcDataType == ipp8u && ippDstDataType == ipp16s) {
             Ipp8u ippbordervalue = (Ipp8u)ippBorderValue;
             status = ippiFilter@filter_type@@filter_magnitude@Border_8u16s_C1R(pSrc, srcStep, pDst,
-            	dstStep, roiSize, maskSize, ippBorderType, ippbordervalue, pBuffer);
+                dstStep, roiSize, maskSize, ippBorderType, ippbordervalue, pBuffer);
         }
         else if (ippSrcDataType == ipp16s && ippDstDataType == ipp16s) {
             // 16s32f_C1R
             Ipp16s ippbordervalue = (Ipp16s)ippBorderValue;
             status = ippiFilter@filter_type@@filter_magnitude@Border_16s_C1R(pSrc, srcStep, pDst,
-            	dstStep, roiSize, maskSize, ippBorderType, ippbordervalue, pBuffer);
+                dstStep, roiSize, maskSize, ippBorderType, ippbordervalue, pBuffer);
         }
         else if (ippSrcDataType == ipp32f && ippDstDataType == ipp32f) {
             // 16u32f_C1R
             Ipp16u ippbordervalue = (Ipp16u)ippBorderValue;
             status = ippiFilter@filter_type@@filter_magnitude@Border_32f_C1R(pSrc, srcStep, pDst,
-            	dstStep, roiSize, maskSize, ippBorderType, ippbordervalue, pBuffer);
+                dstStep, roiSize, maskSize, ippBorderType, ippbordervalue, pBuffer);
         }
         else
         {

--- a/skipp/filters/_filters.pxd
+++ b/skipp/filters/_filters.pxd
@@ -86,3 +86,9 @@ cdef extern from "own_filters.h":
                                 int img_width,
                                 int img_height,
                                 int numChannels)
+
+    IppStatus own_mask_filter_result(IppDataType ippSrcDataType,
+                                     void * pDst,
+                                     int img_width,
+                                     int img_height,
+                                     int numChannels)

--- a/skipp/filters/include/own_filters.h
+++ b/skipp/filters/include/own_filters.h
@@ -36,6 +36,7 @@
 #define OWN_FILTERS_H
 #include <stddef.h>
 #include "ipp.h"
+#include <omp.h>
 #include "_ipp_wr.h"
 #include "utils.h"
 
@@ -204,6 +205,14 @@ own_FilterPrewitt(
     IppDataType ippSrcDataType,
     IppDataType ippDstDataType,
     void * pSrc,
+    void * pDst,
+    int img_width,
+    int img_height,
+    int numChannels);
+
+IppStatus
+own_mask_filter_result(
+    IppDataType ippSrcDataType,
     void * pDst,
     int img_width,
     int img_height,

--- a/skipp/filters/include/own_filters.h
+++ b/skipp/filters/include/own_filters.h
@@ -35,8 +35,10 @@
 #ifndef OWN_FILTERS_H
 #define OWN_FILTERS_H
 #include <stddef.h>
-#include "ipp.h"
-#include <omp.h>
+#include <ipp.h>
+#ifdef USE_OPENMP
+   #include <omp.h>
+#endif
 #include "_ipp_wr.h"
 #include "utils.h"
 

--- a/skipp/filters/src/own_filters.c
+++ b/skipp/filters/src/own_filters.c
@@ -609,7 +609,6 @@ own_mask_filter_result(
 
     IppStatus pStatus[4];
 
-    int max_num_threads;
     int sizeof_dst;
     status = get_sizeof(ippDstDataType, &sizeof_dst);
     check_sts(status);
@@ -625,6 +624,7 @@ own_mask_filter_result(
     IppiSize horizRoiSize = {img_width, 1};
     IppiSize verRoiSize = {1, (img_height - 1)};
 #ifdef USE_OPENMP
+    int max_num_threads;
 #ifdef MAX_NUM_THREADS
     max_num_threads = MAX_NUM_THREADS;
 #else

--- a/skipp/filters/src/own_filters.c
+++ b/skipp/filters/src/own_filters.c
@@ -624,7 +624,7 @@ own_mask_filter_result(
 
     IppiSize horizRoiSize = {img_width, 1};
     IppiSize verRoiSize = {1, (img_height - 1)};
-
+#ifdef USE_OPENMP
 #ifdef MAX_NUM_THREADS
     max_num_threads = MAX_NUM_THREADS;
 #else
@@ -655,6 +655,7 @@ own_mask_filter_result(
     }
     else
     {
+#endif
         status = ippiSet_C1R(ippDstDataType, value, pTop, dstStep, horizRoiSize);
         check_sts(status);
         status = ippiSet_C1R(ippDstDataType, value, pBottom, dstStep, horizRoiSize);
@@ -663,7 +664,9 @@ own_mask_filter_result(
         check_sts(status);
         status = ippiSet_C1R(ippDstDataType, value, pRight, dstStep, verRoiSize);
         check_sts(status);
+#ifdef USE_OPENMP
     }
+#endif
 EXIT_FUNC
     return status;
 }


### PR DESCRIPTION
* implemented native `own_mask_filter_results` 
* currently skiped some `laplace` filter test suits
* template `ippiSet_<mode>_C1R`: added `ippiSet_C1R` adpater

TODO:
* threading `ippiDivC_32f_C1IR`, `ippiSqr_32f_C1IR`, `ippiAdd_32f_C1R`
* threading `own_FilterPrewitt` 
* adding condition before threads init
* for 2 and ?3 threads