### PR TITLE
Hot-fix for float16 datatype

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.2.0" %}
-{% set buildnumber = 6 %}
+{% set buildnumber = 7 %}
 
 package:
     name: scikit-ipp

--- a/skipp/_ipp_utils/_ippi.pxd
+++ b/skipp/_ipp_utils/_ippi.pxd
@@ -25,6 +25,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ******************************************************************************
 
+cdef extern from "ippdefs.h":
+    cdef int COMPILER_SUPPORT_SHORT_FLOAT = 0
+
 cdef extern from "ippbase.h":
     ctypedef enum IppDataType:
         ippUndef = -1
@@ -49,6 +52,7 @@ cdef extern from "ippbase.h":
         ipp64sc = 18
         ipp64f = 19
         ipp64fc = 20
+        ipp16fc = 21
 
 
 cdef extern from "ipptypes.h":


### PR DESCRIPTION
Since ipp have added support for float16, it is required to add some missed definitions in `scikit-ipp` cython layer header (.pxd) for such feature.